### PR TITLE
Use CompletableFuture instead of Future

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,8 @@ projects: [spring-framework]
 :jackson: http://wiki.fasterxml.com/JacksonHome
 :SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
 :EnableAsync: http://docs.spring.io/spring/docs/current/spring-framework-reference/html/scheduling.html#scheduling-annotation-support
-:Future: http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html
+:Future: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Future.html
+:CompletableFuture: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
 :Executor: http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/htmlsingle/#scheduling-task-executor
 :runner: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-command-line-runner
 :toc:
@@ -18,7 +19,7 @@ This guide walks you through the steps to create asynchronous queries to GitHub.
 
 == What you'll build
 
-You'll build a lookup service that queries GitHub user information and retrieves data through GitHub's API. One approach to scaling services is to run expensive jobs in the background and wait for the results using Java's {Future}[`Future`] interface. Java's `Future` is essentially a container housed to hold the potential results. It gives you methods to let you poll if the results have arrived yet, and when they have, the ability to access the results.
+You'll build a lookup service that queries GitHub user information and retrieves data through GitHub's API. One approach to scaling services is to run expensive jobs in the background and wait for the results using Java's {CompletableFuture}[`CompletableFuture`] interface. Java's `CompletableFuture` is an evolution from the regular `Future`. It makes it easy to pipeline multiple asynchronous operations merging them into a single asynchronous computation.
 
 == What you'll need
 
@@ -70,7 +71,7 @@ The `GitHubLookupService` class uses Spring's `RestTemplate` to invoke a remote 
 
 The class is marked with the `@Service` annotation, making it a candidate for Spring's component scanning to detect it and add it to the link:/understanding/application-context[application context].
 
-The `findUser` method is flagged with Spring's `@Async` annotation, indicating it will run on a separate thread. The method's return type is {Future}[`Future<User>`] instead of `User`, a requirement for any asynchronous service. This code uses the concrete implementation of `AsyncResult` to wrap the results of the GitHub query.
+The `findUser` method is flagged with Spring's `@Async` annotation, indicating it will run on a separate thread. The method's return type is {CompletableFuture}[`CompletableFuture<User>`] instead of `User`, a requirement for any asynchronous service. This code uses the `completedFuture` method to return a `CompletableFuture` instance which is already completed with result of the GitHub query.
 
 NOTE: Creating a local instance of the `GitHubLookupService` class does NOT allow the `findUser` method to run asynchronously. It must be created inside a `@Configuration` class or picked up by `@ComponentScan`.
 
@@ -89,7 +90,7 @@ include::complete/src/main/java/hello/Application.java[]
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/spring-boot-application.adoc[]
 
-The {EnableAsync}[`@EnableAsync`] annotation switches on Spring's ability to run `@Async` methods in a background thread pool. This class also extends from `AsyncConfigurerSupport` to tune the `Executor` to use. In our case, we want to limit the number of concurrent threads to 2 and limit the size of the queue to 500. There are {Executor}[many more things you can tune]. By default, a `SimpleAsyncTaskExecutor` is used.
+The {EnableAsync}[`@EnableAsync`] annotation switches on Spring's ability to run `@Async` methods in a background thread pool. This class also customizes the used `Executor`. In our case, we want to limit the number of concurrent threads to 2 and limit the size of the queue to 500. There are {Executor}[many more things you can tune]. By default, a `SimpleAsyncTaskExecutor` is used.
 
 There is also a {runner}[`CommandLineRunner`] that injects the `GitHubLookupService` and calls that service 3 times to demonstrate the method is executed asynchronously.
 
@@ -104,7 +105,8 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/build_an_executable_jar_with_both.adoc[]
 
 
-Logging output is displayed, showing each query to GitHub. Each `Future` result is monitored until available, so when they are all done, the log will print out the results along with the total amount of elapsed time.
+Logging output is displayed, showing each query to GitHub. With the help of `allOf` factory method we create an array of `CompletableFutures` on which by calling the `join`
+method makes it possible to wait for the completion of all of the `CompletableFutures`.
 
 ....
 2016-09-01 10:25:21.295  INFO 17893 --- [ GithubLookup-2] hello.GitHubLookupService                : Looking up CloudFoundry
@@ -118,8 +120,7 @@ Logging output is displayed, showing each query to GitHub. Each `Future` result 
 
 Note that the first two calls happen in separate threads (`GithubLookup-2`, `GithubLookup-1`) and the third one is parked until one of the two threads became available. To compare how long this takes without the asynchronous feature, try commenting out the `@Async` annotation and run the service again. The total elapsed time should increase noticeably because each query takes at least a second. You can also tune the `Executor` to increase the `corePoolSize` attribute for instance.
 
-Essentially, the longer the task takes and the more tasks are invoked simultaneously, the more benefit you will see with making things asynchronous. The trade off is handling the `Future` interface. It adds a layer of indirection because you are no longer dealing directly with the results, but must instead poll for them. If multiple method calls were previously chained together in a synchronous fashion, converting to an asynchronous approach may require synchronizing results. But this extra work may be necessary if asynchronous method calls solves a critical scaling issue.
-
+Essentially, the longer the task takes and the more tasks are invoked simultaneously, the more benefit you will see with making things asynchronous. The trade off is handling the `CompletableFuture` interface. It adds a layer of indirection because you are no longer dealing directly with the results.
 
 == Summary
 

--- a/complete/src/main/java/hello/AppRunner.java
+++ b/complete/src/main/java/hello/AppRunner.java
@@ -1,11 +1,11 @@
 package hello;
 
-import java.util.concurrent.Future;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
 
 @Component
 public class AppRunner implements CommandLineRunner {
@@ -24,20 +24,19 @@ public class AppRunner implements CommandLineRunner {
         long start = System.currentTimeMillis();
 
         // Kick of multiple, asynchronous lookups
-        Future<User> page1 = gitHubLookupService.findUser("PivotalSoftware");
-        Future<User> page2 = gitHubLookupService.findUser("CloudFoundry");
-        Future<User> page3 = gitHubLookupService.findUser("Spring-Projects");
+        CompletableFuture<User> page1 = gitHubLookupService.findUser("PivotalSoftware");
+        CompletableFuture<User> page2 = gitHubLookupService.findUser("CloudFoundry");
+        CompletableFuture<User> page3 = gitHubLookupService.findUser("Spring-Projects");
 
         // Wait until they are all done
-        while (!(page1.isDone() && page2.isDone() && page3.isDone())) {
-            Thread.sleep(10); //10-millisecond pause between each check
-        }
+        CompletableFuture.allOf(page1,page2,page3).join();
 
         // Print results, including elapsed time
         logger.info("Elapsed time: " + (System.currentTimeMillis() - start));
         logger.info("--> " + page1.get());
         logger.info("--> " + page2.get());
         logger.info("--> " + page3.get());
+
     }
 
 }

--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -1,23 +1,24 @@
 package hello;
 
-import java.util.concurrent.Executor;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.util.concurrent.Executor;
+
 @SpringBootApplication
 @EnableAsync
-public class Application extends AsyncConfigurerSupport {
+public class Application {
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+        // close the application context to shut down the custom ExecutorService
+        SpringApplication.run(Application.class, args).close();
     }
 
-    @Override
-    public Executor getAsyncExecutor() {
+    @Bean
+    public Executor asyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);
         executor.setMaxPoolSize(2);
@@ -26,5 +27,6 @@ public class Application extends AsyncConfigurerSupport {
         executor.initialize();
         return executor;
     }
+
 
 }

--- a/complete/src/main/java/hello/GitHubLookupService.java
+++ b/complete/src/main/java/hello/GitHubLookupService.java
@@ -1,14 +1,13 @@
 package hello;
 
-import java.util.concurrent.Future;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.CompletableFuture;
 
 @Service
 public class GitHubLookupService {
@@ -22,13 +21,13 @@ public class GitHubLookupService {
     }
 
     @Async
-    public Future<User> findUser(String user) throws InterruptedException {
+    public CompletableFuture<User> findUser(String user) throws InterruptedException {
         logger.info("Looking up " + user);
         String url = String.format("https://api.github.com/users/%s", user);
         User results = restTemplate.getForObject(url, User.class);
         // Artificial delay of 1s for demonstration purposes
         Thread.sleep(1000L);
-        return new AsyncResult<>(results);
+        return CompletableFuture.completedFuture(results);
     }
 
 }


### PR DESCRIPTION
Since Spring 4.2 a method annotated with `@Async` can return `CompletableFuture`. It would be better to use it instead of `Future` since it provides better chaining capabilities of asynchronous operations, instead of
```
 while (!(page1.isDone() && page2.isDone() && page3.isDone())) {
            Thread.sleep(10); //10-millisecond pause between each check
 }
```
we could do

```
CompletableFuture.allOf(page1,page2,page3).join();
```
