### PR TITLE
Associate the async service to the TaskExecutor

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,7 @@
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-async-method
+:EnableAsyncJavadoc: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/annotation/EnableAsync.html
 This guide walks you through the steps to create asynchronous queries to GitHub. The focus is on the asynchronous part, a feature often used when scaling services.
 
 == What you'll build
@@ -86,7 +87,7 @@ include::complete/src/main/java/hello/Application.java[]
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/spring-boot-application.adoc[]
 
-The {EnableAsync}[`@EnableAsync`] annotation switches on Spring's ability to run `@Async` methods in a background thread pool. This class also customizes the used `Executor`. In our case, we want to limit the number of concurrent threads to 2 and limit the size of the queue to 500. There are {Executor}[many more things you can tune]. By default, a `SimpleAsyncTaskExecutor` is used.
+The {EnableAsync}[`@EnableAsync`] annotation switches on Spring's ability to run `@Async` methods in a background thread pool. This class also customizes the used `Executor` by defining a new bean. Here the method is named `taskExecutor` since this is the {EnableAsyncJavadoc}[specific method name Spring will search for]. In our case, we want to limit the number of concurrent threads to 2 and limit the size of the queue to 500. There are {Executor}[many more things you can tune]. By default, a `SimpleAsyncTaskExecutor` is used.
 
 There is also a {runner}[`CommandLineRunner`] that injects the `GitHubLookupService` and calls that service 3 times to demonstrate the method is executed asynchronously.
 

--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -18,7 +18,7 @@ public class Application {
     }
 
     @Bean
-    public Executor asyncExecutor() {
+    public Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);
         executor.setMaxPoolSize(2);


### PR DESCRIPTION
See issue #12 
Changing method name of Executor bean and adding explanation in the readme