### PR TITLE
Fixed broken link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -163,7 +163,7 @@ class:
 ====
 [source,java]
 ----
-include::complete/src/main/java/hello/AppRunner.java[]
+include::complete/src/main/java/com/example/asyncmethod/AppRunner.java[]
 ----
 ====
 


### PR DESCRIPTION
This trivial P/R fixes a broken link causing the code snippet under https://spring.io/guides/gs/async-method/ to not load. Thank you.
