### PR TITLE
Fix documentation on defalut TaskExecutor: ThreadPoolTaskExecutor

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -135,7 +135,7 @@ a new bean. Here, the method is named `taskExecutor`, since this is the
 {EnableAsyncJavadoc}[specific method name for which Spring searches]. In our case, we want
 to limit the number of concurrent threads to two and limit the size of the queue to 500.
 There are {Executor}[many more things you can tune]. If you do not define an `Executor`
-bean, Spring creates a `SimpleAsyncTaskExecutor` and uses that.
+bean, Spring uses `ThreadPoolTaskExecutor`.
 
 There is also a {runner}[`CommandLineRunner`] that injects the `GitHubLookupService` and
 calls that service three times to demonstrate the method is executed asynchronously.


### PR DESCRIPTION
I have figured out that the default TaskExecutor is not `SimpleAsyncTaskExecutor` but `ThreadPoolTaskExecutor` by reading references:
[SimpleAsyncTaskExecutor fires up only 8 threads - first answer](https://stackoverflow.com/a/58015713)
[SimpleAsyncTaskExecutor fires up only 8 threads - second answer](https://stackoverflow.com/a/61576916)

Also, I have checked it out by myself through using demo code (environment: Kotlin 1.7.22, Spring Boot 3.0.5 & 2.5.13). Below are my codes for the test.

```kotlin
@Configuration
@EnableAsync
class SpringAsyncConfig {
}
```
```kotlin
@Service
class AsyncService(
) {
    @Async
    fun calculate() {
        TimeUnit.SECONDS.sleep(5)
        val currentThread = Thread.currentThread()
        println("@Async annotated method: ${currentThread.threadGroup}, ${currentThread.name}")
    }
}
```
```kotlin
@RestController
@RequestMapping("/demo")
class AsyncController(
    private val asyncService: AsyncService,
) {
    @GetMapping("/async")
    fun async() {
        asyncService.calculate()
        val currentThread = Thread.currentThread()
        println("Controller method: ${currentThread.threadGroup}, ${currentThread.name}")
    }
}
```
```kotlin
@Component
@Order(Ordered.HIGHEST_PRECEDENCE)
class ThreadPoolTaskExecutorBeanProcessor(
    @Autowired private val applicationContext: ApplicationContext
) : BeanPostProcessor {
    override fun postProcessBeforeInitialization(bean: Any, beanName: String): Any? {
        return bean
    }

    override fun postProcessAfterInitialization(bean: Any, beanName: String): Any? {
        return if (bean is ThreadPoolTaskExecutor) {
            createProxy(bean)
        } else bean
    }

    private fun createProxy(executor: ThreadPoolTaskExecutor): Any {
        val proxy: ThreadPoolTaskExecutorProxy = ThreadPoolTaskExecutorProxy()
        proxy.corePoolSize = executor.corePoolSize
        proxy.maxPoolSize = executor.maxPoolSize
        proxy.initialize()
        logg.info("create proxy:")
        logg.info("${proxy.corePoolSize}")

        return proxy
    }

    companion object {
        private val logg = LoggerFactory.getLogger(ThreadPoolTaskExecutorBeanProcessor::class.java)
    }
}

class ThreadPoolTaskExecutorProxy : ThreadPoolTaskExecutor()
```

I have called the api defined on the rest controller. 
And the result is below. As you can see below, the thread's name is `ThreadPoolTaskExecutorProxy` which is a proxy for `ThreadPoolTaskExecutor` not for `SimpleAsyncTaskExecutor`. I have also defined a proxy for `SimpleAsyncTaskExecutor` but I don't think I have to add that code here. It is obvious that the default TaskExecutor is not `SimpleAsyncTaskExecutor`.
```console
Controller method: java.lang.ThreadGroup[name=main,maxpri=10], http-nio-8080-exec-1
@Async annotated method: java.lang.ThreadGroup[name=main,maxpri=10], ThreadPoolTaskExecutorProxy-1
```